### PR TITLE
feat: alter package.path in accordance with the runtimepath

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 format:
-	stylua -v --verify lua/rocks-config/ plugin/
+	stylua -v --verify lua/rocks-dev/ plugin/
 
 check:
-	luacheck lua/rocks-config plugin/
+	luacheck lua/rocks-dev plugin/

--- a/lua/rocks-dev/init.lua
+++ b/lua/rocks-dev/init.lua
@@ -14,7 +14,10 @@ function rocks_dev.setup(user_configuration)
             goto continue
         end
 
-        vim.opt.runtimepath:append(vim.fn.expand(data.dir))
+        local directory = vim.fs.normalize(data.dir)
+
+        vim.opt.runtimepath:append(directory)
+        package.path = package.path .. ";" .. (directory .. "/lua/?.lua") .. ";" .. (directory .. "/lua/?/init.lua")
 
         ::continue::
     end


### PR DESCRIPTION
According to the help pages, both are kept in sync by Neovim, however this doesn't seem to always be consistent. This patch also modifies the package.path to ensure that all Lua modules can be properly located by Neovim.

It's also possible that there's a race condition between rocks-config.nvim and rocks-dev.nvim trying to do the same thing at once - something to look into.