### PR TITLE
feat: use rtp.nvim to source plugin directories

### DIFF
--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -33,6 +33,7 @@ jobs:
           dependencies: |
             rocks.nvim >= 2.10.0
             nvim-nio
+            rtp.nvim
           labels: |
             neovim
           detailed_description: |

--- a/lua/rocks-dev/init.lua
+++ b/lua/rocks-dev/init.lua
@@ -16,7 +16,7 @@ function rocks_dev.setup(user_configuration)
 
         -- NOTE: We can't support `opt` for dev plugins,
         -- as it doesn't integrate with `:Rocks packadd`
-        rocks.source_runtime_dir(data.dir)
+        require("rtp_nvim").source_runtime_dir(data.dir)
 
         ::continue::
     end

--- a/plugin/rocks-dev.lua
+++ b/plugin/rocks-dev.lua
@@ -6,6 +6,10 @@ Example rocks.toml:
 ```
 --]]
 
+if vim.g.rocks_dev_nvim_did_setup then
+    return
+end
+
 local ok, api = pcall(require, "rocks.api")
 
 if not ok then
@@ -16,3 +20,5 @@ end
 local user_configuration = api.get_rocks_toml()
 
 require("rocks-dev").setup(user_configuration)
+
+vim.g.rocks_dev_nvim_did_setup = true


### PR DESCRIPTION
I have extracted the `rocks.api.source_runtime_dir` logic into a [rtp.nvim library](https://github.com/nvim-neorocks/rtp.nvim), because it will no longer be needed by rocks.nvim once https://github.com/nvim-neorocks/rocks.nvim/pull/292 is merged.

When rocks-dev.nvim uses this library, we can deprecate the function in rocks.nvim.