### PR TITLE
fix: use nio.create to remove rock synchronously within pcall

### DIFF
--- a/lua/rocks-dev/local-rock-handler.lua
+++ b/lua/rocks-dev/local-rock-handler.lua
@@ -21,7 +21,7 @@ function rock_handler.get_sync_callback(rock)
         return nio.create(function(report_progress, report_error)
             api.query_installed_rocks(function(rocks)
                 if rocks[rock.name] then
-                    local ok = pcall(operations.remove(rock.name).wait)
+                    local ok = pcall(nio.create(operations.remove(rock.name).wait))
 
                     if not ok then
                         report_error(("rocks-dev: Failed to remove %s"):format(rock.name))


### PR DESCRIPTION
~~To resolve the 2nd error in #16 I wrapped `operations.remove` in `nio.create`. My thinking is the error thrown for calling async in a sync context is related to `pcall` being a sync method. By using `nio.create` rock removal is handled synchronously within `pcall`.~~

Since this occurs in a larger async context created by `api.query_installed_rocks` the overall process should still be async.

Edit: I did more testing locally and have found this does not fix the issue :( I will keep looking at it though!