### PR TITLE
fix: remove local rock outside of sync query_installed_rocks callback

### DIFF
--- a/lua/rocks-dev/local-rock-handler.lua
+++ b/lua/rocks-dev/local-rock-handler.lua
@@ -19,18 +19,26 @@ function rock_handler.get_sync_callback(rock)
         ---@param report_progress fun(message: string)
         ---@param report_error fun(message: string)
         return nio.create(function(report_progress, report_error)
+            local event = nio.control.event()
+            local remove_local_rock = false
+
             api.query_installed_rocks(function(rocks)
                 if rocks[rock.name] then
-                    local ok = pcall(operations.remove(rock.name).wait)
-
-                    if not ok then
-                        report_error(("rocks-dev: Failed to remove %s"):format(rock.name))
-                        return
-                    end
-
-                    report_progress(("rocks-dev: Hotswapped %s"):format(rock.name))
+                    remove_local_rock = true
                 end
+                event.set()
             end)
+
+            event.wait()
+
+            if remove_local_rock then
+                 local ok = pcall(nio.create(operations.remove(rock.name).wait))
+                 if not ok then
+                     report_error(("rocks-dev: Failed to remove %s"):format(rock.name))
+                     return
+                 end
+                 report_progress(("rocks-dev: Hotswapped %s"):format(rock.name))
+            end
         end, 2)
     end
 end


### PR DESCRIPTION
This is a fix for the 2nd error in https://github.com/nvim-neorocks/rocks-dev.nvim/issues/16

I believe the error about calling from a sync context is due to `operations.remove` being called inside of the `query_installed_rocks` callback. By calling from outside of this context the removal works as expected.