### PR TITLE
feat: support dev.path & dev = true

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,25 @@ and you are good to go!
 ## :books: Usage
 
 With this extension, you can add a `dir` field table to plugins in your `rocks.toml`,
-for example
+for example:
 
 ```toml
 [plugins."sweetie.nvim"]
 dir = "~/git/nvim/sweetie.nvim"
 ```
+
+This extension also supports `dev.path`, which allows you to provide the path to where local plugins
+are stored. You can tell rocks-dev to load a plugin from that path with `dev = true`, for example:
+
+```toml
+[dev]
+path = "~/Projects"
+
+[plugins]
+"sweetie.nvim" = { dev = true }
+```
+
+When both `dir` and `dev = true` are present, `dir` gets priority.
 
 ## :book: License
 

--- a/lua/rocks-dev/init.lua
+++ b/lua/rocks-dev/init.lua
@@ -7,13 +7,21 @@ function rocks_dev.setup(user_configuration)
         return
     end
 
+    local dev_path = user_configuration.dev and user_configuration.dev.path
+
     for _, data in pairs(user_configuration.plugins or {}) do
+        local path
         if data.dir then
-            vim.opt.runtimepath:append(vim.fn.expand(data.dir))
+            path = vim.fn.expand(data.dir)
+        elseif dev_path and data.dev then
+            path = vim.fn.expand(vim.fs.joinpath(dev_path, data.name))
+        end
+        if path then
+            vim.opt.runtimepath:append(path)
 
             -- NOTE: We can't support `opt` for dev plugins,
             -- as it doesn't integrate with `:Rocks packadd`
-            require("rtp_nvim").source_rtp_dir(vim.fn.expand(data.dir))
+            require("rtp_nvim").source_rtp_dir(path)
         end
     end
 end

--- a/lua/rocks-dev/local-rock-handler.lua
+++ b/lua/rocks-dev/local-rock-handler.lua
@@ -14,7 +14,8 @@ local rock_handler = {}
 ---@param rock RockSpec
 ---@return async fun(report_progress: fun(message: string), report_error: fun(message: string)) | nil
 function rock_handler.get_sync_callback(rock)
-    if rock.dir then
+    local user_configuration = api.get_rocks_toml()
+    if rock.dir or (rock.dev and user_configuration.dev.path) then
         ---@cast rock DevRockSpec
         ---@param report_progress fun(message: string)
         ---@param report_error fun(message: string)

--- a/spec/load_spec.lua
+++ b/spec/load_spec.lua
@@ -8,17 +8,12 @@ vim.g.rocks_nvim = {
 }
 
 describe("rocks-dev", function()
-    it("can load local plugins with path alias", function()
-        local config_content = [[
-[plugins]
-"foo.nvim" = { dir = "~/Projects/foo.nvim" }
-]]
+    ---Assert that a plugin "foo.nvim" is loaded by the given configuration
+    local function assert_loaded(config_content)
         local fh = assert(io.open(vim.g.rocks_nvim.config_path, "w"), "Could not open rocks.toml for writing")
         fh:write(config_content)
         fh:close()
-        local plugin_content = [[
-vim.g.foo_nvim_loaded = true
-]]
+        local plugin_content = "vim.g.foo_nvim_loaded = true"
         fh = assert(
             io.open(vim.fs.joinpath(tempdir, "Projects", "foo.nvim", "plugin", "foo.lua"), "w"),
             "Could not open config file for writing"
@@ -29,5 +24,28 @@ vim.g.foo_nvim_loaded = true
         local user_configuration = require("rocks.api").get_rocks_toml()
         rocks_dev.setup(user_configuration)
         assert.True(vim.g.foo_nvim_loaded)
+
+        -- reset the variable so that subsequent tests are not affected
+        vim.g.foo_nvim_loaded = nil
+    end
+
+    it("can load local plugins with path alias", function()
+        local config_content = [[
+[plugins]
+"foo.nvim" = { dir = "~/Projects/foo.nvim" }
+]]
+        assert_loaded(config_content)
+    end)
+
+    it("can load local plugins when `dev.path` is set", function()
+        local config_content = [[
+[dev]
+path = "~/Projects"
+
+[plugins]
+"foo.nvim" = { dev = true }
+]]
+
+        assert_loaded(config_content)
     end)
 end)


### PR DESCRIPTION
I'm pretty sure that this works. but `rocks-dev.nvim` doesn't seem to work if it's installed with `rocks-git.nvim` so I don't have a good way to test until it's published I don't think.

Is there a way to further isolate the tests? neovim globals seem to persist between tests so I had to explicitly unset it after each test for it to work. 

---



- [x] Pull request title has the appropriate conventional commit prefix.
- [ ] Tested
    - [x] Tests have been added.
    - [ ] Tested manually. I am unable to test manually, the plugin doesn't seem to work when installed from git.
- [x] Updated documentation.