### PR TITLE
feat(experimental): recognise rocks-dev packages as dependencies

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,24 +1,5 @@
 {
   "nodes": {
-    "cats-doc": {
-      "inputs": {
-        "flake-parts": "flake-parts_6",
-        "nixpkgs": "nixpkgs_6"
-      },
-      "locked": {
-        "lastModified": 1719860562,
-        "narHash": "sha256-zB0xoHts0+K8dO6Gbm+v9bjKHA5POdStdBUjomZTikY=",
-        "owner": "mrcjkb",
-        "repo": "cats-doc",
-        "rev": "8c054023347c9aa577dd3bcbed26e6e0a88900ec",
-        "type": "github"
-      },
-      "original": {
-        "owner": "mrcjkb",
-        "repo": "cats-doc",
-        "type": "github"
-      }
-    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -203,29 +184,6 @@
           "rocks-nvim-flake",
           "neorocks",
           "neovim-nightly",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1717285511,
-        "narHash": "sha256-iKzJcpdXih14qYVcZ9QC9XuZYnPc6T8YImb6dX166kw=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "2a55567fcf15b1b1c7ed712a2c6fadaec7412ea8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-parts_11": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "rocks-nvim-flake",
-          "neorocks",
-          "neovim-nightly",
           "hercules-ci-effects",
           "nixpkgs"
         ]
@@ -241,6 +199,24 @@
       "original": {
         "id": "flake-parts",
         "type": "indirect"
+      }
+    },
+    "flake-parts_11": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_7"
+      },
+      "locked": {
+        "lastModified": 1696343447,
+        "narHash": "sha256-B2xAZKLkkeRFG5XcHHSXXcP7To9Xzr59KXeZiRf4vdQ=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "c9afaba3dfa4085dbd2ccb38dfade5141e33d9d4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
       }
     },
     "flake-parts_2": {
@@ -328,11 +304,11 @@
         "nixpkgs-lib": "nixpkgs-lib_4"
       },
       "locked": {
-        "lastModified": 1696343447,
-        "narHash": "sha256-B2xAZKLkkeRFG5XcHHSXXcP7To9Xzr59KXeZiRf4vdQ=",
+        "lastModified": 1717285511,
+        "narHash": "sha256-iKzJcpdXih14qYVcZ9QC9XuZYnPc6T8YImb6dX166kw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "c9afaba3dfa4085dbd2ccb38dfade5141e33d9d4",
+        "rev": "2a55567fcf15b1b1c7ed712a2c6fadaec7412ea8",
         "type": "github"
       },
       "original": {
@@ -379,7 +355,12 @@
     },
     "flake-parts_9": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_7"
+        "nixpkgs-lib": [
+          "rocks-nvim-flake",
+          "neorocks",
+          "neovim-nightly",
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1717285511,
@@ -416,7 +397,7 @@
     },
     "gen-luarc_2": {
       "inputs": {
-        "flake-parts": "flake-parts_8",
+        "flake-parts": "flake-parts_7",
         "nixpkgs": [
           "rocks-nvim-flake",
           "nixpkgs"
@@ -490,7 +471,7 @@
       "inputs": {
         "flake-compat": "flake-compat_7",
         "gitignore": "gitignore_4",
-        "nixpkgs": "nixpkgs_7",
+        "nixpkgs": "nixpkgs_6",
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
@@ -698,7 +679,7 @@
     },
     "hercules-ci-effects_2": {
       "inputs": {
-        "flake-parts": "flake-parts_11",
+        "flake-parts": "flake-parts_10",
         "nixpkgs": [
           "rocks-nvim-flake",
           "neorocks",
@@ -745,10 +726,10 @@
     "neorocks_2": {
       "inputs": {
         "flake-compat": "flake-compat_6",
-        "flake-parts": "flake-parts_9",
+        "flake-parts": "flake-parts_8",
         "git-hooks": "git-hooks_3",
         "neovim-nightly": "neovim-nightly_2",
-        "nixpkgs": "nixpkgs_9"
+        "nixpkgs": "nixpkgs_8"
       },
       "locked": {
         "lastModified": 1719552233,
@@ -790,11 +771,11 @@
     "neovim-nightly_2": {
       "inputs": {
         "flake-compat": "flake-compat_8",
-        "flake-parts": "flake-parts_10",
+        "flake-parts": "flake-parts_9",
         "git-hooks": "git-hooks_4",
         "hercules-ci-effects": "hercules-ci-effects_2",
         "neovim-src": "neovim-src_2",
-        "nixpkgs": "nixpkgs_8"
+        "nixpkgs": "nixpkgs_7"
       },
       "locked": {
         "lastModified": 1719467057,
@@ -902,20 +883,14 @@
     },
     "nixpkgs-lib_4": {
       "locked": {
-        "dir": "lib",
-        "lastModified": 1696019113,
-        "narHash": "sha256-X3+DKYWJm93DRSdC5M6K5hLqzSya9BjibtBsuARoPco=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "f5892ddac112a1e9b3612c39af1b72987ee5783a",
-        "type": "github"
+        "lastModified": 1717284937,
+        "narHash": "sha256-lIbdfCsf8LMFloheeE6N31+BMIeixqyQWbSr2vk79EQ=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/eb9ceca17df2ea50a250b6b27f7bf6ab0186f198.tar.gz"
       },
       "original": {
-        "dir": "lib",
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/eb9ceca17df2ea50a250b6b27f7bf6ab0186f198.tar.gz"
       }
     },
     "nixpkgs-lib_5": {
@@ -944,14 +919,20 @@
     },
     "nixpkgs-lib_7": {
       "locked": {
-        "lastModified": 1717284937,
-        "narHash": "sha256-lIbdfCsf8LMFloheeE6N31+BMIeixqyQWbSr2vk79EQ=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/eb9ceca17df2ea50a250b6b27f7bf6ab0186f198.tar.gz"
+        "dir": "lib",
+        "lastModified": 1696019113,
+        "narHash": "sha256-X3+DKYWJm93DRSdC5M6K5hLqzSya9BjibtBsuARoPco=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f5892ddac112a1e9b3612c39af1b72987ee5783a",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/eb9ceca17df2ea50a250b6b27f7bf6ab0186f198.tar.gz"
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "nixpkgs-stable": {
@@ -1083,22 +1064,6 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1697379843,
-        "narHash": "sha256-RcnGuJgC2K/UpTy+d32piEoBXq2M+nVFzM3ah/ZdJzg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "12bdeb01ff9e2d3917e6a44037ed7df6e6c3df9d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_7": {
-      "locked": {
         "lastModified": 1719082008,
         "narHash": "sha256-jHJSUH619zBQ6WdC21fFAlDxHErKVDJ5fpN0Hgx4sjs=",
         "owner": "NixOS",
@@ -1113,7 +1078,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_8": {
+    "nixpkgs_7": {
       "locked": {
         "lastModified": 1719379843,
         "narHash": "sha256-u+D+IOAMMl70+CJ9NKB+RMrASjInuIWMHzjLWQjPZ6c=",
@@ -1129,7 +1094,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_9": {
+    "nixpkgs_8": {
       "locked": {
         "lastModified": 1719468428,
         "narHash": "sha256-vN5xJAZ4UGREEglh3lfbbkIj+MPEYMuqewMn4atZFaQ=",
@@ -1140,6 +1105,22 @@
       },
       "original": {
         "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_9": {
+      "locked": {
+        "lastModified": 1697379843,
+        "narHash": "sha256-RcnGuJgC2K/UpTy+d32piEoBXq2M+nVFzM3ah/ZdJzg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "12bdeb01ff9e2d3917e6a44037ed7df6e6c3df9d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
         "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
@@ -1194,21 +1175,21 @@
     },
     "rocks-nvim-flake": {
       "inputs": {
-        "cats-doc": "cats-doc",
-        "flake-parts": "flake-parts_7",
+        "flake-parts": "flake-parts_6",
         "gen-luarc": "gen-luarc_2",
         "neorocks": "neorocks_2",
         "nixpkgs": [
           "nixpkgs"
         ],
-        "pre-commit-hooks": "pre-commit-hooks_2"
+        "pre-commit-hooks": "pre-commit-hooks_2",
+        "vimcats": "vimcats"
       },
       "locked": {
-        "lastModified": 1720562405,
-        "narHash": "sha256-JRJNAbLCV2K6wXKTWWvsBh+3921Cg+l2tvz2BvfOQAA=",
+        "lastModified": 1725251181,
+        "narHash": "sha256-u4GtAAxfVgWQzQOcb/1a1G+bjD7/fFjTNwqnl9q+QI8=",
         "owner": "nvim-neorocks",
         "repo": "rocks.nvim",
-        "rev": "735f4a036b0008586b299c1fcd16a1014e3c8c83",
+        "rev": "79123d6d6acc14a0388738e194a9c8d1f1948aff",
         "type": "github"
       },
       "original": {
@@ -1225,6 +1206,25 @@
         "nixpkgs": "nixpkgs_5",
         "pre-commit-hooks": "pre-commit-hooks",
         "rocks-nvim-flake": "rocks-nvim-flake"
+      }
+    },
+    "vimcats": {
+      "inputs": {
+        "flake-parts": "flake-parts_11",
+        "nixpkgs": "nixpkgs_9"
+      },
+      "locked": {
+        "lastModified": 1724691612,
+        "narHash": "sha256-YZPLZgC0v5zw/+X3r0G1MZ+46c0K8J3ClFQYH5BqbUE=",
+        "owner": "mrcjkb",
+        "repo": "vimcats",
+        "rev": "a51bfb9587f95b8fd6a588bdfe97b7f8f4b1e624",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mrcjkb",
+        "repo": "vimcats",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -62,7 +62,7 @@
         luarc = pkgs.mk-luarc {
           nvim = pkgs.neovim-nightly;
           plugins = with pkgs.lua51Packages; [
-            rocks-nvim
+            inputs.rocks-nvim-flake.packages.${pkgs.system}.rocks-nvim
             nvim-nio
           ];
           disabled-diagnostics = [

--- a/lua/rocks-dev/local-rock-handler.lua
+++ b/lua/rocks-dev/local-rock-handler.lua
@@ -1,45 +1,50 @@
 local api = require("rocks.api")
 local nio = require("nio")
 
---- HACK: This is not part of the public rocks.nvim API!
---- Instead of accessing this directly, we should expose it via rocks.api
-local operations = require("rocks.operations.helpers")
-
 local rock_handler = {}
 
 ---@class DevRockSpec: RockSpec
 ---@field name string Name of the plugin.
 ---@field dir string
 
+local ROCKS_DEV_VERSION = "rocksdev"
+
 ---@param rock RockSpec
----@return async fun(on_progress: fun(message: string), on_error: fun(message: string)) | nil
+---@return async fun(on_progress: fun(message: string), on_error: fun(message: string), on_success?: fun(opts: rock_handler.on_success.Opts)) | nil
 function rock_handler.get_sync_callback(rock)
     local user_configuration = api.get_rocks_toml()
     if rock.dir or (rock.dev and user_configuration.dev.path) then
         ---@cast rock DevRockSpec
         ---@param on_progress fun(message: string)
-        ---@param on_error fun(message: string)
-        return nio.create(function(on_progress, on_error)
+        ---@param _ fun(message: string) on_error
+        ---@param on_success? fun(opts: rock_handler.on_success.Opts)
+        return nio.create(function(on_progress, _, on_success)
             local future = nio.control.future()
             api.query_installed_rocks(function(rocks)
-                if rocks[rock.name] then
+                local installed_rock = rocks[rock.name]
+                if installed_rock and installed_rock.version ~= ROCKS_DEV_VERSION then
                     future.set(true)
                 else
                     future.set(false)
                 end
             end)
 
-            local remove_local_rock = future.wait()
+            local hotswapped = future.wait()
 
-            if remove_local_rock then
-                local ok = pcall(nio.create(operations.remove(rock.name).wait))
-                if not ok then
-                    on_error(("rocks-dev: Failed to remove %s"):format(rock.name))
-                    return
-                end
+            if type(on_success) == "function" then
+                on_success({
+                    action = "install",
+                    rock = {
+                        name = rock.name,
+                        version = ROCKS_DEV_VERSION,
+                    },
+                })
+            end
+
+            if hotswapped then
                 on_progress(("rocks-dev: Hotswapped %s"):format(rock.name))
             end
-        end, 2)
+        end, 3)
     end
 end
 

--- a/lua/rocks-dev/local-rock-handler.lua
+++ b/lua/rocks-dev/local-rock-handler.lua
@@ -12,14 +12,14 @@ local rock_handler = {}
 ---@field dir string
 
 ---@param rock RockSpec
----@return async fun(report_progress: fun(message: string), report_error: fun(message: string)) | nil
+---@return async fun(on_progress: fun(message: string), on_error: fun(message: string)) | nil
 function rock_handler.get_sync_callback(rock)
     local user_configuration = api.get_rocks_toml()
     if rock.dir or (rock.dev and user_configuration.dev.path) then
         ---@cast rock DevRockSpec
-        ---@param report_progress fun(message: string)
-        ---@param report_error fun(message: string)
-        return nio.create(function(report_progress, report_error)
+        ---@param on_progress fun(message: string)
+        ---@param on_error fun(message: string)
+        return nio.create(function(on_progress, on_error)
             local future = nio.control.future()
             api.query_installed_rocks(function(rocks)
                 if rocks[rock.name] then
@@ -34,10 +34,10 @@ function rock_handler.get_sync_callback(rock)
             if remove_local_rock then
                 local ok = pcall(nio.create(operations.remove(rock.name).wait))
                 if not ok then
-                    report_error(("rocks-dev: Failed to remove %s"):format(rock.name))
+                    on_error(("rocks-dev: Failed to remove %s"):format(rock.name))
                     return
                 end
-                report_progress(("rocks-dev: Hotswapped %s"):format(rock.name))
+                on_progress(("rocks-dev: Hotswapped %s"):format(rock.name))
             end
         end, 2)
     end


### PR DESCRIPTION
Makes uses of the new experimental API for tricking luarocks into recognising packages managed by external modules as dependencies. 

See:

- https://github.com/nvim-neorocks/rocks.nvim/issues/365

Requires the following experimental feature to be enabled in rocks.nvim:

```lua
vim.g.rocks_nvim = {
  -- ...
  experimental_features = {
    "ext_module_dependency_stubs",
  },
}
```
Depends on: https://github.com/nvim-neorocks/rocks.nvim/pull/492