### PR TITLE
feat(experimental): install rockspec dependencies

### DIFF
--- a/lua/rocks-dev/local-rock-handler.lua
+++ b/lua/rocks-dev/local-rock-handler.lua
@@ -1,9 +1,10 @@
 local api = require("rocks.api")
+local rockspec = require("rocks-dev.rockspec")
 local nio = require("nio")
 
 local rock_handler = {}
 
----@class DevRockSpec: RockSpec
+---@class rocks-dev.DevRockSpec: RockSpec
 ---@field name string Name of the plugin.
 ---@field dir string
 
@@ -14,7 +15,7 @@ local ROCKS_DEV_VERSION = "rocksdev"
 function rock_handler.get_sync_callback(rock)
     local user_configuration = api.get_rocks_toml()
     if rock.dir or (rock.dev and user_configuration.dev.path) then
-        ---@cast rock DevRockSpec
+        ---@cast rock rocks-dev.DevRockSpec
         ---@param on_progress fun(message: string)
         ---@param _ fun(message: string) on_error
         ---@param on_success? fun(opts: rock_handler.on_success.Opts)
@@ -38,6 +39,7 @@ function rock_handler.get_sync_callback(rock)
                         name = rock.name,
                         version = ROCKS_DEV_VERSION,
                     },
+                    dependencies = rockspec.get_dependencies(rock),
                 })
             end
 

--- a/lua/rocks-dev/rockspec.lua
+++ b/lua/rocks-dev/rockspec.lua
@@ -1,0 +1,56 @@
+---@mod rocks-dev.rockspec
+---
+---@brief [[
+---
+---Get dependencies from a rockspec in the repository root
+---
+---@brief ]]
+
+-- Copyright (C) 2024 Neorocks Org.
+--
+-- License:    GPLv3
+-- Created:    03 Sep 2024
+-- Updated:    03 Sep 2024
+-- Homepage:   https://github.com/nvim-neorocks/rocks-git.nvim
+-- Maintainer: mrcjkb <marc@jakobi.dev>
+
+local log = require("rocks.log")
+
+-- NOTE: This module shares code with rocks-git.nvim
+-- It's too soon to abstract it out, but it could potentially become part
+-- of the rocks.nvim API.
+local rockspec = {}
+
+---@param rock_spec rocks-dev.DevRockSpec
+---@return string[]
+function rockspec.get_dependencies(rock_spec)
+    local rockspec_paths = vim.fs.find(function(name, path)
+        return rock_spec.dir == path
+            and vim
+                .iter({ "scm", "dev", "git" })
+                ---@param specrev string
+                :map(function(specrev)
+                    return rock_spec.name .. "%-" .. specrev .. "%-%d.rockspec"
+                end)
+                ---@param pattern string
+                :any(function(pattern)
+                    return name:match(pattern) ~= nil
+                end)
+    end, {
+        path = rock_spec.dir,
+        upward = false,
+    })
+    if vim.tbl_isempty(rockspec_paths) then
+        return {}
+    end
+    local rockspec_path = rockspec_paths[1]
+    local rockspec_tbl = {}
+    xpcall(function()
+        loadfile(rockspec_path, "t", rockspec_tbl)()
+    end, function(err)
+        log.error("rocks-git: Could not load rockspec: " .. err)
+    end)
+    return rockspec_tbl.dependencies or {}
+end
+
+return rockspec

--- a/spec/rockspec_spec.lua
+++ b/spec/rockspec_spec.lua
@@ -1,0 +1,29 @@
+local tempdir = vim.fn.tempname()
+local plugin_dir = vim.fs.joinpath(tempdir, "foo.nvim")
+vim.env.HOME = tempdir
+vim.system({ "rm", "-r", tempdir }):wait()
+vim.system({ "mkdir", "-p", plugin_dir }):wait()
+
+local rockspec = require("rocks-dev.rockspec")
+describe("rockspec", function()
+    describe("get_dependencies", function()
+        local rockspec_content = [[
+package = "foo.nvim"
+version = "scm-1"
+
+dependencies = {
+  "bar >= 1.0.0",
+}
+]]
+        local fh = io.open(vim.fs.joinpath(plugin_dir, "foo.nvim-scm-1.rockspec"), "w+")
+        assert(fh, "Cound not open rockspec for writing")
+        fh:write(rockspec_content)
+        fh:close()
+        ---@diagnostic disable-next-line: missing-fields
+        local dependencies = rockspec.get_dependencies({
+            name = "foo.nvim",
+            dir = plugin_dir,
+        })
+        assert.same({ "bar >= 1.0.0" }, dependencies)
+    end)
+end)


### PR DESCRIPTION
See also: https://github.com/nvim-neorocks/rocks.nvim/pull/527

Requires an up-to-date rocks.nvim with the following experimental feature enabled:

```lua
vim.g.rocks_nvim = {
  -- ...
  experimental_features = {
    "ext_module_dependency_stubs",
  },
}
```